### PR TITLE
add SMTcoin solona token list

### DIFF
--- a/src/SMTcoin.json
+++ b/src/SMTcoin.json
@@ -1,0 +1,12 @@
+{
+  "chainId": 101,
+  "address": "BV8WoHydNQHGTQqvhdJcT54TRrZtBjofxpssehCMPJ3V",
+  "symbol": "SMT",
+  "name": "SMTcoin",
+  "decimals": 9,
+  "logoURI": "https://raw.githubusercontent.com/dlamare/token-list/main/assets/mainnet/BV8WoHydNQHGTQqvhdJcT54TRrZtBjofxpssehCMPJ3V/logo.png",
+  "tags": ["community-token"],
+  "extensions": {
+    "telegram": "https://t.me/pinetworkun1"
+  }
+}


### PR DESCRIPTION
This PR adds SMTcoin to the Solana token list.

- Name: SMTcoin
- Symbol: SMT
- Address: BV8WoHydNQHGTQqvhdJcT54TRrZtBjofxpssehCMPJ3V
- Chain ID: 101
- Logo: Included in assets/mainnet/BV8WoHydNQHGTQqvhdJcT54TRrZtBjofxpssehCMPJ3V/logo.png

Thank you!